### PR TITLE
Fix build errors in `adriangb:mutable-language`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
     let mut directories = options.values_of("directories").unwrap();
     let outfile = Path::new(options.value_of(ARG_OUTPUT_FILE).unwrap());
 
-    let lang: Box<dyn Language> = match language_type {
+    let mut lang: Box<dyn Language> = match language_type {
         Some("swift") => Box::new(Swift {
             prefix: config.swift.prefix,
             type_mappings: config.swift.type_mappings,

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -175,7 +175,7 @@ impl Language for Kotlin {
 }
 
 impl Kotlin {
-    fn write_enum_variants(&self, w: &mut dyn Write, e: &RustEnum) -> std::io::Result<()> {
+    fn write_enum_variants(&mut self, w: &mut dyn Write, e: &RustEnum) -> std::io::Result<()> {
         match e {
             RustEnum::Unit(shared) => {
                 for v in &shared.variants {
@@ -294,7 +294,7 @@ impl Kotlin {
     }
 
     fn write_element(
-        &self,
+        &mut self,
         w: &mut dyn Write,
         f: &RustField,
         generic_types: &[String],

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -24,7 +24,11 @@ pub use typescript::TypeScript;
 pub trait Language {
     /// Given `data`, generate type-code for this language and write it out to `writable`.
     /// Returns whether or not writing was successful.
-    fn generate_types(&mut self, writable: &mut dyn Write, data: &ParsedData) -> std::io::Result<()> {
+    fn generate_types(
+        &mut self,
+        writable: &mut dyn Write,
+        data: &ParsedData,
+    ) -> std::io::Result<()> {
         self.begin_file(writable)?;
 
         for a in &data.aliases {

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -20,7 +20,7 @@ mod blocklisted_types {
 
         let mut out: Vec<u8> = Vec::new();
         assert!(matches!(
-            process_input(&source, &TypeScript::default(), &mut out),
+            process_input(&source, &mut TypeScript::default(), &mut out),
             Err(ProcessInputError::ParseError(
                 ParseError::RustTypeParseError(RustTypeParseError::UnsupportedType(contents))
             )) if contents == vec![blocklisted_type.to_owned()]
@@ -79,7 +79,7 @@ mod serde_attributes_on_enums {
 
         let mut out: Vec<u8> = Vec::new();
         assert!(matches!(
-            process_input(source, &TypeScript::default(), &mut out).unwrap_err(),
+            process_input(source, &mut TypeScript::default(), &mut out).unwrap_err(),
             ProcessInputError::ParseError(ParseError::SerdeContentNotAllowed { enum_ident }) if enum_ident == "Foo"
         ));
     }
@@ -97,7 +97,7 @@ mod serde_attributes_on_enums {
 
         let mut out: Vec<u8> = Vec::new();
         assert!(matches!(
-            process_input(source, &TypeScript::default(), &mut out).unwrap_err(),
+            process_input(source, &mut TypeScript::default(), &mut out).unwrap_err(),
             ProcessInputError::ParseError(ParseError::SerdeTagNotAllowed { enum_ident }) if enum_ident == "Foo"
         ));
     }
@@ -115,7 +115,7 @@ mod serde_attributes_on_enums {
 
         let mut out: Vec<u8> = Vec::new();
         assert!(matches!(
-            process_input(source, &TypeScript::default(), &mut out).unwrap_err(),
+            process_input(source, &mut TypeScript::default(), &mut out).unwrap_err(),
             ProcessInputError::ParseError(ParseError::SerdeTagNotAllowed { enum_ident }) if enum_ident == "Foo"
         ));
     }

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -52,7 +52,7 @@ fn load_file(path: impl AsRef<Path>) -> Result<String, anyhow::Error> {
 fn check(
     test_name: &str,
     file_name: impl AsRef<Path>,
-    lang: Box<dyn Language>,
+    mut lang: Box<dyn Language>,
 ) -> Result<(), anyhow::Error> {
     let _extension = file_name
         .as_ref()


### PR DESCRIPTION
This fixes the errors by moving the borrows outside of closure and fixing several miscellaneous borrowing issues.